### PR TITLE
Fix gallery

### DIFF
--- a/lib/providers/transactions.dart
+++ b/lib/providers/transactions.dart
@@ -82,11 +82,13 @@ Future<void> addTransactions(
 
 Future<void> deleteTransaction(
     String customerId, String hashcode, String imgUrl) async {
+  // 개별 사진을 지움
+  await firebase_storage.FirebaseStorage.instance.refFromURL(imgUrl).delete();
+
+  // transaction 자체를 지움
   late final CollectionReference? txs;
   FirebaseFirestore _fireStoreDatabase = FirebaseFirestore.instance;
   txs = _fireStoreDatabase.collection('tx/$customerId/purchase');
-
-  await firebase_storage.FirebaseStorage.instance.refFromURL(imgUrl).delete();
 
   return txs
       .doc(hashcode.toString())

--- a/lib/providers/transactions.dart
+++ b/lib/providers/transactions.dart
@@ -80,10 +80,13 @@ Future<void> addTransactions(
       .catchError((error) => print("Failed to Add Customers: $error"));
 }
 
-Future<void> deleteTransaction(String customerId, String hashcode) {
+Future<void> deleteTransaction(
+    String customerId, String hashcode, String imgUrl) async {
   late final CollectionReference? txs;
   FirebaseFirestore _fireStoreDatabase = FirebaseFirestore.instance;
-  txs = _fireStoreDatabase.collection('tx/${customerId}/purchase');
+  txs = _fireStoreDatabase.collection('tx/$customerId/purchase');
+
+  await firebase_storage.FirebaseStorage.instance.refFromURL(imgUrl).delete();
 
   return txs
       .doc(hashcode.toString())

--- a/lib/widgets/customer_tx_card.dart
+++ b/lib/widgets/customer_tx_card.dart
@@ -27,7 +27,7 @@ class TxCard extends StatelessWidget {
       trailing: IconButton(
         icon: const Icon(Icons.delete),
         onPressed: () {
-          deleteTransaction(customerId, data.id);
+          deleteTransaction(customerId, data.id, data.imgUrl);
         },
       ),
       onTap: () => {


### PR DESCRIPTION
* customer 지울때 해당 커스터머의 tx 남아있던거 지우고, storage에 있는 이미지도 찾아서 지움
* customer의 tx를 지울때 storage에 있는 이미지 지움. 

귀찮아서 대충 짠다고 안했는데, 그랬더니 없는 customer/히스토리의 사진을 보여줘서부랴부랴 고침. 